### PR TITLE
Jamie

### DIFF
--- a/public/ads.index.php
+++ b/public/ads.index.php
@@ -12,8 +12,7 @@
     // extract() will turn all the associative indices in the above $data array into variables that can be called directly later.
     // For example: $data['ads'] can now just be called by $ads
     extract(pageController()); 
-      
-    
+        
 ?>
 
 <!doctype html>
@@ -21,7 +20,7 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Adlister | Home</title>
+    <title>Adlister | All Ads</title>
 
 <?php require_once '../views/partials/header.php'; ?>
 </head>
@@ -42,16 +41,11 @@
                 <div class="large-4 medium-6 columns">       
                     <div class="ad">
                         <div class="panel">
-                            <h3><a href="ads.show.php"><?= $ad['title']; ?></a></h3>
-                            <a href="ads.show.php"><img src="<?= $ad['image_url']; ?>"></a>
-                            <p>Description: <?= $ad['description']; ?></p>
-                            <p>Price: $<?= $ad['price']; ?></p>
-                            <p>Contact <?= $ad['contact_name']; ?> if interested:
-                                <ul>
-                                    <li>Email: <?= $ad['contact_email']; ?></li>
-                                    <li>Cell: <?= $ad['contact_phone']; ?></li>
-                                </ul>
-                            </p>
+                            <h3><a href="ads.show.php?id=<?= $ad['id']; ?>"><?= $ad['title']; ?></a></h3>
+                            <a href="ads.show.php?id=<?= $ad['id']; ?>"><img src="<?= $ad['image_url']; ?>"></a>
+                            <p><span class="pre">Description</span><span class="description"><?= $ad['description']; ?></span></p>
+                            <p><span class="pre">Price</span><span class="price">$<?= $ad['price']; ?></p>
+                            <p class="view-ad"><a href="ads.show.php?id=<?= $ad['id']; ?>">View <i class="fa fa-chevron-circle-right"></i></a></span></p>
                         </div>
                     </div>
                 </div>

--- a/public/ads.show.php
+++ b/public/ads.show.php
@@ -1,4 +1,22 @@
 <!-- Shows a single ad that has been clicked from the ads.index.php-->
+
+<?php 
+    require_once($_SERVER['DOCUMENT_ROOT'].'../../bootstrap.php');
+    require_once($_SERVER['DOCUMENT_ROOT'].'../../models/Ad.php');
+
+    function pageController()
+    {
+        $data =['ads' => Ad::all()];
+
+        return $data;   
+
+    }
+    // extract() will turn all the associative indices in the above $data array into variables that can be called directly later.
+    // For example: $data['ads'] can now just be called by $ads
+    extract(pageController()); 
+
+?>
+
 <!doctype html>
 <html lang="en-US" class="no-js">
 <head>
@@ -13,16 +31,28 @@
 <?php require_once '../views/partials/navbar.php'; ?>
 
 <div class="ads">
-	<h3>2005 Chrysler Sebring</h3>
-	<img src="img/myVehicle.jpg">
-	<p><Description:</strong> Good condition, minor body work, no mechanical problems.</p>
-	<p>Price: $2,500</p>
-	<p>Contact Jamie if interested:
-		<ul>
-			<li>Email: email@gmail.com</li>
-			<li>Cell: 555-555-5555</li>
-		</ul>
-	</p>
+	<div class="large-4 medium-6 columns">       
+        <div class="ad">
+            <div class="panel">
+
+				<?php foreach($ads as $ad) { ?>
+					<?php if($ad['id'] == $_GET['id']) { ?>
+						<h3><?= $ad['title']; ?></h3>
+					    <a href="#"><img src="<?= $ad['image_url']; ?>"></a>
+					    <p><span class="pre">Description</span><span class="description"><?= $ad['description']; ?></span></p>
+					    <p><span class="pre">Price</span><span class="price">$<?= $ad['price']; ?></span></p>
+					    <p>Contact <?= $ad['contact_name']; ?> if interested:
+					        <ul>
+					            <li>Email: <?= $ad['contact_email']; ?></li>
+					            <li>Cell: <?= $ad['contact_phone']; ?></li>
+					        </ul>
+					    </p>
+					<?php } ?>
+				<?php } ?>
+
+            </div>
+        </div>
+    </div>
 </div>
 
 <?php require_once '../views/partials/footer.php'; ?>


### PR DESCRIPTION
-`ads.show.php` now displays the correct ad using a $_GET along with the contact info

-`ads.index.php` no longer displays contact info and includes the styling for class='panel' and class='pre' for "Description:" and "Price:"
